### PR TITLE
Fix locale provider and update widget tests

### DIFF
--- a/lib/provider/provider.dart
+++ b/lib/provider/provider.dart
@@ -12,7 +12,7 @@ class LocaleProvider with ChangeNotifier {
   Future<void> loadLocale() async {
     final prefs = await SharedPreferences.getInstance();
     String? langCode = prefs.getString('language_code');
-    if (langCode != null) {
+    if (langCode != null && _locale == const Locale('he', 'IL')) {
       _locale = Locale(langCode);
       notifyListeners();
     }

--- a/test/bottom_nav_bar_test.dart
+++ b/test/bottom_nav_bar_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_app/widgets/bottom_nav_bar.dart';
 import 'package:flutter_app/provider/provider.dart';
+import 'package:flutter_app/l10n/localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -11,6 +13,17 @@ void main() {
     return ChangeNotifierProvider(
       create: (_) => LocaleProvider()..setLocale(const Locale('en', 'US')),
       child: MaterialApp(
+        supportedLocales: const [
+          Locale('en', 'US'),
+          Locale('he', 'IL'),
+          Locale('zh', 'ZH'),
+        ],
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
         home: Scaffold(
           bottomNavigationBar: CustomBottomNavBar(
             selectedIndex: 0,

--- a/test/food_page_test.dart
+++ b/test/food_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_app/pages/food_page.dart';
 import 'package:flutter_app/mongo_methods/mongo_methods.dart';
 import 'package:flutter_app/provider/provider.dart';
+import 'package:flutter_app/l10n/localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'fake_mongo_service.dart';
@@ -21,7 +23,20 @@ void main() {
   Widget buildApp() {
     return ChangeNotifierProvider(
       create: (_) => LocaleProvider()..setLocale(const Locale('en', 'US')),
-      child: const MaterialApp(home: FoodPage()),
+      child: MaterialApp(
+        supportedLocales: const [
+          Locale('en', 'US'),
+          Locale('he', 'IL'),
+          Locale('zh', 'ZH'),
+        ],
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: const FoodPage(),
+      ),
     );
   }
 

--- a/test/pupu_page_test.dart
+++ b/test/pupu_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_app/pages/pupu_page.dart';
 import 'package:flutter_app/mongo_methods/mongo_methods.dart';
 import 'package:flutter_app/provider/provider.dart';
+import 'package:flutter_app/l10n/localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'fake_mongo_service.dart';
@@ -21,7 +23,20 @@ void main() {
   Widget buildApp() {
     return ChangeNotifierProvider(
       create: (_) => LocaleProvider()..setLocale(const Locale('en', 'US')),
-      child: const MaterialApp(home: PupuPage()),
+      child: MaterialApp(
+        supportedLocales: const [
+          Locale('en', 'US'),
+          Locale('he', 'IL'),
+          Locale('zh', 'ZH'),
+        ],
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: const PupuPage(),
+      ),
     );
   }
 

--- a/test/snack_page_test.dart
+++ b/test/snack_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_app/pages/snack_page.dart';
 import 'package:flutter_app/mongo_methods/mongo_methods.dart';
 import 'package:flutter_app/provider/provider.dart';
+import 'package:flutter_app/l10n/localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'fake_mongo_service.dart';
@@ -21,7 +23,20 @@ void main() {
   Widget buildApp() {
     return ChangeNotifierProvider(
       create: (_) => LocaleProvider()..setLocale(const Locale('en', 'US')),
-      child: const MaterialApp(home: SnackPage()),
+      child: MaterialApp(
+        supportedLocales: const [
+          Locale('en', 'US'),
+          Locale('he', 'IL'),
+          Locale('zh', 'ZH'),
+        ],
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: const SnackPage(),
+      ),
     );
   }
 

--- a/test/walk_page_test.dart
+++ b/test/walk_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_app/pages/walk_page.dart';
 import 'package:flutter_app/mongo_methods/mongo_methods.dart';
 import 'package:flutter_app/provider/provider.dart';
+import 'package:flutter_app/l10n/localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'fake_mongo_service.dart';
@@ -22,7 +24,20 @@ void main() {
   Widget buildApp() {
     return ChangeNotifierProvider(
       create: (_) => LocaleProvider()..setLocale(const Locale('en', 'US')),
-      child: const MaterialApp(home: WalkPage()),
+      child: MaterialApp(
+        supportedLocales: const [
+          Locale('en', 'US'),
+          Locale('he', 'IL'),
+          Locale('zh', 'ZH'),
+        ],
+        localizationsDelegates: const [
+          AppLocalizationsDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: const WalkPage(),
+      ),
     );
   }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,13 +7,35 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-// import 'package:flutter_application/main.dart';
+
+class TestCounter extends StatefulWidget {
+  const TestCounter({super.key});
+
+  @override
+  State<TestCounter> createState() => _TestCounterState();
+}
+
+class _TestCounterState extends State<TestCounter> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Text('$count'),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => setState(() => count++),
+          child: const Icon(Icons.add),
+        ),
+      ),
+    );
+  }
+}
 
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    // await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const TestCounter());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- prevent race condition when loading locale
- add localization delegates to widget tests
- provide a small counter widget in `widget_test.dart`

## Testing
- `flutter test` *(fails: Got socket error trying to find package intl)*