### PR TITLE
Add tests and optimize API switch

### DIFF
--- a/lib/mongo_methods/mongo_methods.dart
+++ b/lib/mongo_methods/mongo_methods.dart
@@ -71,10 +71,12 @@ class MongoDatabase {
     return client;
   }
 
-  static Future<void> switchToNoCacheUrlTemporarily() async {
+  static Future<void> switchToNoCacheUrlTemporarily() {
     currentApiUrl = apiUrlNoCache;
-    await Future.delayed(const Duration(seconds: 5));
-    currentApiUrl = apiUrlCloudfront;
+    Timer(const Duration(seconds: 5), () {
+      currentApiUrl = apiUrlCloudfront;
+    });
+    return Future.value();
   }
 
   static Future<bool> checkUserLoginStatus() async {

--- a/test/mongo_methods_test.dart
+++ b/test/mongo_methods_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_app/mongo_methods/mongo_methods.dart';
+
+void main() {
+  test('switchToNoCacheUrlTemporarily changes URL temporarily', () {
+    fakeAsync((async) {
+      currentApiUrl = apiUrlCloudfront;
+      MongoDatabase.switchToNoCacheUrlTemporarily();
+      expect(currentApiUrl, apiUrlNoCache);
+      async.elapse(const Duration(seconds: 5));
+      expect(currentApiUrl, apiUrlCloudfront);
+    });
+  });
+}

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_app/provider/provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('LocaleProvider persists locale', () async {
+    SharedPreferences.setMockInitialValues({});
+    final provider = LocaleProvider();
+    await provider.setLocale(const Locale('en', 'US'));
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(provider.locale, const Locale('en'));
+    expect(prefs.getString('language_code'), 'en');
+
+    final newProvider = LocaleProvider();
+    await newProvider.loadLocale();
+    expect(newProvider.locale, const Locale('en'));
+  });
+
+  test('BackgroundColorProvider persists color', () async {
+    SharedPreferences.setMockInitialValues({});
+    final provider = BackgroundColorProvider();
+    await provider.setColor(Colors.grey);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(provider.color, const Color(0xFF9E9E9E));
+    expect(prefs.getInt('background_color'), Colors.grey.value);
+
+    final newProvider = BackgroundColorProvider();
+    await newProvider.loadColor();
+    expect(newProvider.color, const Color(0xFF9E9E9E));
+  });
+}


### PR DESCRIPTION
## Summary
- avoid blocking delay in `switchToNoCacheUrlTemporarily`
- add tests for providers persistence
- add test for temporary API URL switch

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_685aaa3fa0f483259bb79b1a9061201e